### PR TITLE
added ShowMainWindowAtActivate preference and user default

### DIFF
--- a/English.lproj/Preferences.xib
+++ b/English.lproj/Preferences.xib
@@ -22,13 +22,24 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button id="4">
-                        <rect key="frame" x="58" y="33" width="208" height="18"/>
+                        <rect key="frame" x="58" y="40" width="208" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <buttonCell key="cell" type="check" title="Show main window at startup" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="5">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                             <connections>
                                 <binding destination="6" name="value" keyPath="values.ShowMainWindowAtStartup" id="7"/>
+                            </connections>
+                        </buttonCell>
+                    </button>
+                    <button id="9">
+                        <rect key="frame" x="58" y="20" width="216" height="18"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <buttonCell key="cell" type="check" title="Show main window at activation" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="10">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <connections>
+                                <binding destination="6" name="value" keyPath="values.ShowMainWindowAtActivate" id="11"/>
                             </connections>
                         </buttonCell>
                     </button>

--- a/Source/DiskArbitratorAppController.m
+++ b/Source/DiskArbitratorAppController.m
@@ -70,6 +70,7 @@
 	NSMutableDictionary *defaults = [NSMutableDictionary dictionary];
 	[defaults setObject:[NSNumber numberWithInt:LOG_INFO] forKey:AppLogLevelDefaultsKey];
 	[defaults setObject:[NSNumber numberWithBool:YES]     forKey:@"ShowMainWindowAtStartup"];
+	[defaults setObject:[NSNumber numberWithBool:NO]     forKey:@"ShowMainWindowAtActivate"];
 	[[NSUserDefaults standardUserDefaults] registerDefaults:defaults];
 	
 	displayErrorQueue = [NSMutableArray new];
@@ -104,6 +105,12 @@
 	[tableView registerForDraggedTypes:[NSArray arrayWithObject:NSFilenamesPboardType]];
 	
 	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"ShowMainWindowAtStartup"])
+		[window makeKeyAndOrderFront:self];
+}
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification
+{
+	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"ShowMainWindowAtActivate"])
 		[window makeKeyAndOrderFront:self];
 }
 


### PR DESCRIPTION
This show the main window when application is already running and is activated through a launcher (Launchbar, etc.)  or double click.

With this, we can show the main window without using the menu item.

A typical use is to drag and drop a disk image while the app is blocking mounts.

Initial default is NO by default to keep currents workflows.