### PR TITLE
Spelling

### DIFF
--- a/Source/SheetController.h
+++ b/Source/SheetController.h
@@ -18,6 +18,6 @@
 
 - (IBAction)alternate:(id)sender;
 - (IBAction)cancel:(id)sender;
-- (IBAction)ok:(id)sener;
+- (IBAction)ok:(id)sender;
 
 @end

--- a/Source/SheetController.m
+++ b/Source/SheetController.m
@@ -35,7 +35,7 @@
 	[NSApp endSheet:self.window returnCode:NSModalResponseCancel];
 }
 
-- (IBAction)ok:(id)sener
+- (IBAction)ok:(id)sender
 {
 	[self.window endEditingFor:nil];
 	[NSApp endSheet:self.window returnCode:NSModalResponseOK];

--- a/scripts/markdown.pl
+++ b/scripts/markdown.pl
@@ -878,7 +878,7 @@ sub _DoLists {
 	# same script on the same server ran fine *except* under MT. I've spent
 	# more time trying to figure out why this is happening than I'd like to
 	# admit. My only guess, backed up by the fact that this workaround works,
-	# is that Perl optimizes the substition when it can figure out that the
+	# is that Perl optimizes the substitution when it can figure out that the
 	# pattern will never change, and when this optimization isn't on, we run
 	# afoul of the reaper. Thus, the slightly redundant code that uses two
 	# static s/// patterns rather than one conditional pattern.

--- a/scripts/markdown.pl
+++ b/scripts/markdown.pl
@@ -1042,7 +1042,7 @@ sub _DoCodeSpans {
 #         <p>Just type <code>foo `bar` baz</code> at the prompt.</p>
 #     
 #		There's no arbitrary limit to the number of backticks you
-#		can use as delimters. If you need three consecutive backticks
+#		can use as delimiters. If you need three consecutive backticks
 #		in your code, use four for delimiters, etc.
 #
 #	*	You can use spaces to get literal backticks at the edges:


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`